### PR TITLE
Fixed the DANB model and too few genes issue

### DIFF
--- a/R/methods_sc_analysis.R
+++ b/R/methods_sc_analysis.R
@@ -790,6 +790,13 @@ S7::method(vision_w_autocor_sc, single_cell_exp) <- function(
 #' @returns A data.table with the auto-correlations on a per gene basis and
 #' various statistics.
 #'
+#' @details
+#' Should a gene not be found in sufficient cells, the gene will be
+#' automatically filtered out from the results. This can occur for example
+#' if you have filtered out the cells that contain a given gene. The underlying
+#' genes are still available, but the cells that might contain them are not
+#' included.
+#'
 #' @export
 hotspot_autocor_sc <- S7::new_generic(
   name = "hotspot_autocor_sc",
@@ -940,6 +947,12 @@ S7::method(hotspot_autocor_sc, single_cell_exp) <- function(
 #' @param .verbose Boolean. Controls verbosity of the function.
 #'
 #' @returns A `sc_hotspot` class that can be used for subsequent analysis.
+#'
+#' @details
+#' Should a gene not be found in sufficient cells, the pairs with this gene
+#' will be set to 0. Please ensure prior to running the function that you
+#' are only calculating gene-gene auto-correlations that occur in sufficient
+#' cells.
 #'
 #' @export
 hotspot_gene_cor_sc <- S7::new_generic(

--- a/man/hotspot_autocor_sc.Rd
+++ b/man/hotspot_autocor_sc.Rd
@@ -75,3 +75,10 @@ calculate the auto-correlation of a given gene in the kNN graph based on
 the chosen embedding. This can be used to identify genes that have strong
 local correlations and vary across the kNN graph.
 }
+\details{
+Should a gene not be found in sufficient cells, the gene will be
+automatically filtered out from the results. This can occur for example
+if you have filtered out the cells that contain a given gene. The underlying
+genes are still available, but the cells that might contain them are not
+included.
+}

--- a/man/hotspot_gene_cor_sc.Rd
+++ b/man/hotspot_gene_cor_sc.Rd
@@ -72,3 +72,9 @@ A \code{sc_hotspot} class that can be used for subsequent analysis.
 This method implements the HotSpot approach (see DeTomaso, et al.) to
 calculate the local gene-gene correlations and their Z-scores.
 }
+\details{
+Should a gene not be found in sufficient cells, the pairs with this gene
+will be set to 0. Please ensure prior to running the function that you
+are only calculating gene-gene auto-correlations that occur in sufficient
+cells.
+}

--- a/misc/scripts/workbench_skunk_works.R
+++ b/misc/scripts/workbench_skunk_works.R
@@ -1,160 +1,35 @@
-# test seacell -----------------------------------------------------------------
-
-Sys.setenv(OPENBLAS_NUM_THREADS = "1")
-Sys.setenv(OMP_NUM_THREADS = "1")
-
-rextendr::document()
+# fix hotspot ------------------------------------------------------------------
 
 devtools::load_all()
 
-sessionInfo()
+dir_data <- path.expand("~/Downloads/single_cell_data/")
 
-data_dir <- path.expand("~/Desktop/seacell_test/")
-
-sc_object <- single_cell_exp(dir_data = tempdir())
-
-h5_path <- path.expand(
-  "~/repos/other/Hotspot/notebooks/5k_h5ad.h5ad"
+sc_object <- single_cell_exp(
+  dir_data = dir_data
 )
 
-sc_object <- load_h5ad(
-  sc_object,
-  h5_path = h5_path,
-  streaming = FALSE
-)
+sc_object <- load_existing(sc_object)
 
-sc_object <- find_hvg_sc(
+dim(get_knn_mat(sc_object))
+
+dim(get_pca_factors(sc_object))
+
+hotspot_autocor_danb_res <- hotspot_autocor_sc(
+  hotspot_params = params_sc_hotspot(),
   object = sc_object,
-  hvg_no = 2000L,
-  .verbose = FALSE
-)
-
-sc_object <- calculate_pca_sc(
-  object = sc_object,
-  no_pcs = 30L,
-  randomised_svd = TRUE,
-  .verbose = FALSE
-)
-
-# sea_cells <- get_seacells_sc(
-#   sc_object,
-#   seacell_params = params_sc_seacells(
-#     n_sea_cells = 90L,
-#     knn = list(k = 15L),
-#     convergence_epsilon = 1e-5,
-#     max_fw_iters = 50L,
-#     pruning = TRUE
-#   )
-# )
-
-object = sc_object
-
-hotspot_params = params_sc_hotspot(
-  model = "danb",
-  knn = list(ann_dist = "cosine", k = 30L),
-  normalise = TRUE
-)
-
-tictoc::tic()
-hotspot_auto_cor <- rs_hotspot_autocor(
-  f_path_genes = get_rust_count_gene_f_path(object),
-  f_path_cells = get_rust_count_cell_f_path(object),
-  embd = get_pca_factors(object),
-  hotspot_params = hotspot_params,
-  cells_to_keep = get_cells_to_keep(object),
-  genes_to_use = get_gene_indices(
-    object,
-    gene_ids = get_gene_names(object),
-    rust_index = TRUE
-  ),
-  streaming = FALSE,
-  verbose = TRUE,
-  seed = 42L
-)
-tictoc::toc()
-
-hotspot_auto_cor_dt <- as.data.table(hotspot_auto_cor)[,
-  gene_name := get_gene_names(object)
-]
-
-setorder(hotspot_auto_cor_dt, -z_score)
-
-hotspot_python <- fread(
-  "~/repos/other/Hotspot/notebooks/hotspot_python_results.csv"
-)
-
-combined = merge(
-  hotspot_python[, c("Gene", "C", "Z")],
-  hotspot_auto_cor_dt[, c("gaerys_c", "gene_name", "z_score")],
-  by.x = "Gene",
-  by.y = "gene_name"
-)
-
-plot(combined$C, combined$gaerys_c)
-
-plot(combined$Z, combined$z_score)
-
-tictoc::tic()
-hotspot_gene_cor <- rs_hotspot_gene_cor(
-  f_path_genes = get_rust_count_gene_f_path(object),
-  f_path_cells = get_rust_count_cell_f_path(object),
-  embd = get_pca_factors(object),
-  hotspot_params = hotspot_params,
-  cells_to_keep = get_cells_to_keep(object),
-  genes_to_use = as.integer(hotspot_auto_cor_dt$gene_idx[1:2500]),
+  embd_to_use = "pca",
   streaming = TRUE,
-  verbose = TRUE,
-  seed = 42L
-)
-tictoc::toc()
-
-heatmap(hotspot_gene_cor$z)
-
-hotspot_gene_cor$z[1:10, 1:10]
-
-hist(hotspot_auto_cor$gaerys_c)
-
-hist(hotspot_auto_cor$z_score)
-
-table(hotspot_auto_cor$fdr <= 0.05)
-
-seacell_result <- fread("/Users/gregor/Desktop/seacell_results.csv")
-
-class(object)
-
-plot(
-  x = seq_len(length(sea_cells@other_data$rss)),
-  y = sea_cells@other_data$rss
+  .verbose = TRUE
 )
 
+get_sc_var(sc_object)
 
-object = sea_cells
-original_cell_type = seacell_result$celltype
+weird_genes <- get_gene_indices(
+  sc_object,
+  gene_ids = hotspot_autocor_danb_res$gene_id[is.na(
+    hotspot_autocor_danb_res$pval
+  )],
+  rust_index = FALSE
+)
 
-
-sea_cells <- calc_meta_cell_purity(sea_cells, seacell_result$celltype)
-
-
-internal_results <- data.table(
-  cell_id = sc_object[["index"]],
-  assignment = sea_cells@original_assignment$assignments
-)[, cell_type := seacell_result$celltype]
-
-
-table(internal_results$assignment)
-
-mclust::adjustedRandIndex(internal_results$assignment, seacell_result$SEACell)
-
-sea_cells@obs_table$no_originating_cells
-
-# > sea_cells@obs_table$no_originating_cells
-#  [1]  56  48  47  78  69  59 127  90  66 210  34  49  35  50  66  93  76  37  40  36 180  43  65  76  54 246  71  34  81  66  89  58  49  47  41  48  34
-# [38]  25  93  31  72  64  46  47  82 166 102 234  60  40  33  34 105  49  65 123  34 169 119 164  19  34  71  32  23 150  76  93  53  49  83  20 112  87
-# [75] 124  71  72  48 128 210  19  32  82 155 178  22  58  62  42  71
-
-# > sea_cells@obs_table$no_originating_cells
-#  [1]  57  51  49  79  69  56 119  87  68 178  33  49  37  53  66  93  77  38  43  41 170  46  63  69  55 247  76  31  74  67  87  56  45  50  48  45  35
-# [38]  24 101  29  69  70  46  42  80 166 105 263  60  40  35  34 100  50  59 141  35 177 120 158  20  33  71  35  23 150  79 100  47  42  78  21 118  81
-# [75] 127  80  69  52 128 202  19  30  82 161 169  18  56  62  42  75
-
-rss_vals_wo_pruning <- sea_cells@other_data$rss
+Matrix::colSums(sc_object[, weird_genes, return_format = "gene"])

--- a/src/Makevars
+++ b/src/Makevars
@@ -36,7 +36,7 @@ $(STATLIB):
 	rm -Rf $(CARGOTMP);
 
 rust_clean: $(SHLIB)
-	rm -Rf $(CARGOTMP) $(VENDOR_DIR) $(TARGET_DIR)
+	rm -Rf $(CARGOTMP) $(VENDOR_DIR) 
 
 clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR) $(VENDOR_DIR)

--- a/src/rust/src/single_cell/methods/vision_hotspot.rs
+++ b/src/rust/src/single_cell/methods/vision_hotspot.rs
@@ -4,8 +4,6 @@ use indexmap::IndexSet;
 use rayon::prelude::*;
 use std::time::Instant;
 
-use std::collections::HashSet;
-
 use crate::assert_same_len;
 use crate::core::base::linear_algebra::linear_regression;
 use crate::core::base::stats::{calc_fdr, inv_logit, logit, z_scores_to_pval};
@@ -1075,36 +1073,30 @@ fn danb_model(
 ) -> (Vec<f32>, Vec<f32>, Vec<f32>) {
     let n = n_cells as f32;
     let total: f32 = umi_counts.iter().sum();
-
     let tj: f32 = gene.data_raw.iter().map(|&x| x as f32).sum();
 
-    let mu = umi_counts
-        .iter()
-        .map(|&ti| tj * ti / total)
-        .collect::<Vec<f32>>();
+    let mu: Vec<f32> = umi_counts.iter().map(|&ti| tj * ti / total).collect();
+
+    // Build dense array for O(1) lookups
+    let mut data_dense = vec![0.0f32; n_cells];
+    for (&idx, &val) in gene.indices.iter().zip(&gene.data_raw) {
+        data_dense[idx as usize] = val as f32;
+    }
 
     let mut sum_sq = 0_f32;
-    for (&idx, &val) in gene.indices.iter().zip(&gene.data_raw) {
-        let diff = val as f32 - mu[idx as usize];
+    for i in 0..n_cells {
+        let diff = data_dense[i] - mu[i];
         sum_sq += diff * diff;
     }
 
-    for i in 0..n_cells {
-        if !gene.indices.contains(&(i as u32)) {
-            sum_sq += mu[i] * mu[i];
-        }
-    }
     let vv = sum_sq / (n - 1.0);
-
     let tis_sq_sum: f32 = umi_counts.iter().map(|&ti| ti.powi(2)).sum();
     let mut size = ((tj * tj) / total) * (tis_sq_sum / total) / ((n - 1.0) * vv - tj);
 
-    let min_size = 1e-10;
     if size < 0.0 {
         size = 1e9;
-    }
-    if size < min_size && size >= 0.0 {
-        size = min_size;
+    } else if size < 1e-10 {
+        size = 1e-10;
     }
 
     let var: Vec<f32> = mu.iter().map(|&m| m * (1.0 + m / size)).collect();
@@ -1451,9 +1443,11 @@ impl<'a> Hotspot<'a> {
         let mut z_scores: Vec<f64> = Vec::with_capacity(res.len());
 
         for (idx, c, z) in res {
-            gene_indices.push(idx);
-            gaery_c.push(c as f64);
-            z_scores.push(z as f64);
+            if !z.is_nan() {
+                gene_indices.push(idx);
+                gaery_c.push(c as f64);
+                z_scores.push(z as f64);
+            }
         }
 
         let end_calculations = start_calculation.elapsed();
@@ -1497,6 +1491,8 @@ impl<'a> Hotspot<'a> {
         verbose: bool,
     ) -> Result<HotSpotGeneRes, String> {
         const GENE_BATCH_SIZE: usize = 1000;
+
+        let start_all = Instant::now();
 
         let no_genes = gene_indices.len();
         let no_batches = no_genes.div_ceil(GENE_BATCH_SIZE);
@@ -1547,9 +1543,11 @@ impl<'a> Hotspot<'a> {
             let mut batch_z_scores: Vec<f64> = Vec::with_capacity(batch_res.len());
 
             for (idx, c, z) in batch_res {
-                batch_gene_indices.push(idx);
-                batch_gaery_c.push(c as f64);
-                batch_z_scores.push(z as f64);
+                if z.is_finite() {
+                    batch_gene_indices.push(idx);
+                    batch_gaery_c.push(c as f64);
+                    batch_z_scores.push(z as f64);
+                }
             }
 
             let end_calc = start_calc.elapsed();
@@ -1573,6 +1571,12 @@ impl<'a> Hotspot<'a> {
 
         let p_vals = z_scores_to_pval(&z_scores, "twosided")?;
         let fdrs = calc_fdr(&p_vals);
+
+        let end_total = start_all.elapsed();
+
+        if verbose {
+            println!("Finished the full run in : {:.2?}.", end_total);
+        }
 
         Ok(HotSpotGeneRes {
             gene_idx: gene_indices,
@@ -1777,10 +1781,12 @@ impl<'a> Hotspot<'a> {
         let mut z_mat = Mat::zeros(n_genes, n_genes);
 
         for (i, j, lc, z) in results {
-            lc_mat[(i, j)] = lc;
-            lc_mat[(j, i)] = lc;
-            z_mat[(i, j)] = z;
-            z_mat[(j, i)] = z;
+            if z.is_finite() {
+                lc_mat[(i, j)] = lc;
+                lc_mat[(j, i)] = lc;
+                z_mat[(i, j)] = z;
+                z_mat[(j, i)] = z;
+            }
         }
 
         let lc_maxs = compute_local_cov_pairs_max(&self.node_degrees, &counts_mat);
@@ -1837,8 +1843,6 @@ impl<'a> Hotspot<'a> {
 
         let mut lc_mat = Mat::zeros(n_genes, n_genes);
         let mut z_mat = Mat::zeros(n_genes, n_genes);
-
-        let mut seen_pairs = HashSet::new();
 
         if verbose {
             println!("Processing {} genes in {} batches", n_genes, n_batches);
@@ -1975,8 +1979,8 @@ impl<'a> Hotspot<'a> {
                     .collect();
 
                 for (i, j, lc, z, lc_max) in results {
-                    if !seen_pairs.insert((i, j)) {
-                        println!("DUPLICATE: ({}, {})", i, j);
+                    if !z.is_finite() {
+                        continue;
                     }
                     let normalised_lc = if lc_max > 0.0 { lc / lc_max } else { 0.0 };
 


### PR DESCRIPTION
- The hotspot auto-correlation functions will automatically remove the genes that have Z score of `NA`. This occurs when there are no or too few cells expressing a gene
- The hotspot gene-gene correlation will leave the values for genes that are expressed in too few genes as 0 and not update them. 
- Documentation is updated to reflect this.
- DANB model was made WAY faster via O(1) lookups. The other models had already the improved logic. 