### PR TITLE
Accepted review fixes (onto feat-citeseq) + Cargo.toml build fix

### DIFF
--- a/R/classes_single_cell_db.R
+++ b/R/classes_single_cell_db.R
@@ -1192,12 +1192,13 @@ SingleCellDuckDB <- R6::R6Class(
         obs_parts[[i]] <- obs_dt
       }
 
-      shared_cols <- Reduce(intersect, lapply(obs_parts, names))
-      obs_parts <- lapply(obs_parts, function(dt) {
-        dt[, .SD, .SDcols = shared_cols]
-      })
-
-      obs_combined <- data.table::rbindlist(obs_parts, use.names = TRUE)
+      # keep the union of all obs columns; columns absent from a given file are
+      # NA-filled rather than silently dropped (cell_id / exp_id always present)
+      obs_combined <- data.table::rbindlist(
+        obs_parts,
+        use.names = TRUE,
+        fill = TRUE
+      )
       obs_combined[, cell_idx := .I]
       data.table::setcolorder(
         obs_combined,
@@ -1793,12 +1794,13 @@ SingleCellDuckDB <- R6::R6Class(
         obs_parts[[i]] <- obs_dt
       }
 
-      shared_cols <- Reduce(intersect, lapply(obs_parts, names))
-      obs_parts <- lapply(obs_parts, function(dt) {
-        dt[, .SD, .SDcols = shared_cols]
-      })
-
-      obs_combined <- data.table::rbindlist(obs_parts, use.names = TRUE)
+      # keep the union of all obs columns; columns absent from a given file are
+      # NA-filled rather than silently dropped (cell_id / exp_id always present)
+      obs_combined <- data.table::rbindlist(
+        obs_parts,
+        use.names = TRUE,
+        fill = TRUE
+      )
       obs_combined[, cell_idx := .I]
       data.table::setcolorder(
         obs_combined,
@@ -1953,12 +1955,13 @@ SingleCellDuckDB <- R6::R6Class(
         obs_parts[[i]] <- dt
       }
 
-      shared_cols <- Reduce(intersect, lapply(obs_parts, names))
-      obs_parts <- lapply(obs_parts, function(d) {
-        d[, .SD, .SDcols = shared_cols]
-      })
-
-      combined <- data.table::rbindlist(obs_parts, use.names = TRUE)
+      # keep the union of all obs columns; columns absent from a given file are
+      # NA-filled rather than silently dropped (cell_id / exp_id always present)
+      combined <- data.table::rbindlist(
+        obs_parts,
+        use.names = TRUE,
+        fill = TRUE
+      )
       combined[, cell_idx := .I]
       data.table::setcolorder(
         combined,

--- a/R/functions_gse.R
+++ b/R/functions_gse.R
@@ -260,13 +260,13 @@ simplify_hypergeom_res <- function(
   checkmate::qassert(min_sim, "N1[0, 1]")
 
   # function body
-  ancestry <- get_ontology_ancestry(go_parent_child_dt)
+  ancestry <- get_ontology_ancestry(parent_child_dt)
 
   descendants <- ancestry$descendants
 
   wang_sims <- calculate_wang_sim(
     terms = res$gene_set_name,
-    parent_child_dt = go_parent_child_dt,
+    parent_child_dt = parent_child_dt,
     weights = weights,
     add_self = TRUE
   )
@@ -300,8 +300,8 @@ simplify_hypergeom_res <- function(
         descendants[subset$gene_set_name],
         length
       )
-      to_select_desc <- which(no_descendants == min(no_descendants))
-      to_remove <- append(to_remove, subset$gene_set_name[-to_select])
+      to_select_desc <- which.min(no_descendants)
+      to_remove <- append(to_remove, subset$gene_set_name[-to_select_desc])
     }
   }
 

--- a/R/methods_bulk.R
+++ b/R/methods_bulk.R
@@ -933,9 +933,9 @@ S7::method(calculate_dge_limma, BulkDge) <- function(
 
       # Limma Voom
       limma_results <- run_limma_voom(
-        meta_data = sample_info,
+        meta_data = data.table::copy(sample_info_red),
         main_contrast = contrast_column,
-        dge_list = dge_list,
+        dge_list = dge_list_red,
         contrast_list = contrast_list,
         co_variates = co_variates,
         quantile_norm = quantile_norm,

--- a/R/methods_coexp_cor.R
+++ b/R/methods_coexp_cor.R
@@ -1829,7 +1829,7 @@ coremo_tree_cut <- function(
     sort(unique(clusters)),
     \(cluster_i) {
       x <-
-        prcomp(t(d[names(clusters)[clusters == cluster_i], ]), 1)$x[, "PC1"]
+        prcomp(t(dist_mat[names(clusters)[clusters == cluster_i], ]), 1)$x[, "PC1"]
     }
   ) %>%
     do.call(rbind, .) %>%
@@ -1839,7 +1839,7 @@ coremo_tree_cut <- function(
 
   eg_cor <- rs_cor(x = t(eg), spearman = spearman)
   eg_cor <-
-    abs(eg_cor[to_keep, toMerge, drop = FALSE])
+    abs(eg_cor[to_keep, to_merge, drop = FALSE])
   res <- clusters
   for (i in to_merge) {
     sel_clust <- to_keep[which.max(eg_cor[, as.character(i)])]

--- a/R/methods_graphs.R
+++ b/R/methods_graphs.R
@@ -177,7 +177,7 @@ S7::method(tied_diffusion, NetworkDiffusions) <-
     for (node in seed_nodes_2) {
       diff_vec_2[node] <- diffusion_vector_2[node]
     }
-    if ((sum(diff_vec_1) == 0) || (sum(diff_vec_1) == 0)) {
+    if ((sum(diff_vec_1) == 0) || (sum(diff_vec_2) == 0)) {
       stop(
         paste(
           "No scores found on first and/or second of the diffusion vectors.",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -34,10 +34,7 @@ rand = { version = "0.9.0", features = ["std"] }
 rayon = "1.11.0"
 rustc-hash = "2.1.1"
 thousands = "*"
-bixverse-rs = {
-    version = "0.3.0",
-    features = ["single-cell", "multi-modal"]
-}
+bixverse-rs = { version = "0.3.0", features = ["single-cell", "multi-modal"] }
 either = "1.15.0"
 
 [[bin]]

--- a/src/rust/src/single_cell/r_count_obj.rs
+++ b/src/rust/src/single_cell/r_count_obj.rs
@@ -566,7 +566,7 @@ impl SingleCellCountData {
         let tasks: Vec<H5adFileTask> = file_tasks
             .into_iter()
             .map(|(_, robj)| {
-                let inner_list = List::try_from(robj).expect("Each file_task must be a list");
+                let inner_list = List::try_from(robj)?;
                 H5adFileTask::from_r_list(inner_list)
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -720,7 +720,7 @@ impl SingleCellCountData {
         let tasks: Vec<MtxFileTask> = file_tasks
             .into_iter()
             .map(|(_, robj)| {
-                let inner = List::try_from(robj).expect("Each file_task must be a list");
+                let inner = List::try_from(robj)?;
                 MtxFileTask::from_r_list(inner)
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -863,7 +863,9 @@ impl SingleCellCountData {
         let mut data: Vec<AssayData> = Vec::new();
         let mut indices: Vec<Vec<i32>> = Vec::new();
         let mut indptr: Vec<usize> = Vec::new();
-        let assay_type = parse_count_type(assay).unwrap();
+        let assay_type = parse_count_type(assay).ok_or_else(|| {
+            extendr_api::Error::Other(format!("Invalid assay '{assay}'. Use 'raw' or 'norm'."))
+        })?;
 
         if cell_based {
             let reader = ParallelSparseReader::new(&self.f_path_cells).to_extendr()?;
@@ -938,7 +940,9 @@ impl SingleCellCountData {
         assay: &str,
     ) -> Result<List, extendr_api::Error> {
         let reader = ParallelSparseReader::new(&self.f_path_cells).to_extendr()?;
-        let assay_type = parse_count_type(assay).unwrap();
+        let assay_type = parse_count_type(assay).ok_or_else(|| {
+            extendr_api::Error::Other(format!("Invalid assay '{assay}'. Use 'raw' or 'norm'."))
+        })?;
 
         let indices: Vec<usize> = indices.iter().map(|x| (*x - 1) as usize).collect();
 
@@ -1331,7 +1335,7 @@ impl SingleCellCountData {
                         gene_id,
                         true,
                     );
-                    writer.write_gene_chunk(chunk).unwrap();
+                    writer.write_gene_chunk(chunk).to_extendr()?;
                 } else {
                     let empty_chunk = CscGeneChunk::from_conversion(
                         RawCounts::U16(Vec::new()),
@@ -1386,7 +1390,9 @@ impl SingleCellCountData {
     ) -> Result<List, extendr_api::Error> {
         let reader = ParallelSparseReader::new(&self.f_path_genes).to_extendr()?;
 
-        let assay_type = parse_count_type(assay).unwrap();
+        let assay_type = parse_count_type(assay).ok_or_else(|| {
+            extendr_api::Error::Other(format!("Invalid assay '{assay}'. Use 'raw' or 'norm'."))
+        })?;
 
         let no_cells = reader.get_header().total_cells;
 


### PR DESCRIPTION
Reduced and retargeted from `main` → `feat-citeseq` per @GregorLueg's review. This now contains **only the standalone fixes that were accepted and aren't already on `feat-citeseq`**, plus a build fix.

### Bug fixes (R)
- `functions_gse.R` — `simplify_hypergeom_res` referenced an undefined global `go_parent_child_dt`; now uses the `parent_child_dt` argument, and applies the most-specific (`which.min`) tie-break that was previously dead code.
- `methods_bulk.R` — `calculate_dge_limma`'s `filter_column` branch ran DGE on the full data; now passes the reduced `meta_data`/`dge_list` (mirrors `calculate_dge_hedges`).
- `methods_coexp_cor.R` — `coremo_tree_cut` referenced undefined `d`/`toMerge`.
- `methods_graphs.R` — `tied_diffusion` zero-score guard tested `diff_vec_1` twice.
- `classes_single_cell_db.R` — the three multi-file obs readers dropped columns present in only some files; now `rbindlist(fill = TRUE)`.

### Panic → error (Rust)
- `r_count_obj.rs` — `parse_count_type().unwrap()` ×3, the two `from_r_list` `.expect()`s, and the memory-bounded `write_gene_chunk().unwrap()` now return catchable errors.

### Build fix
- `src/rust/Cargo.toml` — `bixverse-rs` was a multi-line inline table (invalid TOML); `cargo build` fails on it. Reformatted to a single-line table. (Heads-up: `feat-citeseq` also sets `rust-version = "1.90"`.)

### Dropped from the original PR (per review)
- Multi-mtx R loader, bbknn character-batch fix — already implemented natively on `feat-citeseq`.
- cisTarget / Wang `par_iter` — omitted (inner loop already parallel; outer-loop contention).
- PFlog1pPF stored-norm overwrite — deferred to GregorLueg/bixverse-rs#26 (PCA-time offset transform).

Verified locally: `R CMD INSTALL` against `bixverse-rs 0.3.0` + targeted tinytests (gsea / hypergeom / dge / cor_modules / graph_diff / sc_io) — **282/282 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
