### PR TITLE
docs: single-cell I/O vignette

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -43,6 +43,8 @@ navbar:
       menu:
         - text: Thinking about single cells the bixverse way
           href: articles/thinking_single_cell.html
+        - text: "Reading data in (single-cell I/O)"
+          href: articles/single_cell_io.html
         - text: PBMC analysis with the bixverse single cell framework
           href: articles/pbmc_single_cell.html
         - text: Doublet detection in bixverse
@@ -87,6 +89,7 @@ articles:
     navbar: Single Cells
     contents:
       - thinking_single_cell
+      - single_cell_io
       - pbmc_single_cell
       - doublet_detection
       - single_cell_batch_corrections

--- a/vignettes/single_cell_io.qmd
+++ b/vignettes/single_cell_io.qmd
@@ -1,0 +1,282 @@
+---
+title: "Single-cell data I/O in bixverse"
+date: last-modified
+date-format: YYYY-MM-DD
+vignette: >
+  %\VignetteIndexEntry{Single-cell data I/O in bixverse}
+  %\VignetteEngine{quarto::html}
+  %\VignetteEncoding{UTF-8}
+knitr:
+  opts_chunk:
+    collapse: true
+    comment: '#>'
+author:
+  - name: "Gregor Lueg"
+---
+
+## Intro
+
+`bixverse` keeps single-cell counts on disk -- a compact Rust binary for the
+count matrix and a DuckDB for the `obs` / `var` metadata -- so that millions of
+cells can be analysed on a laptop. Ingestion happens once, up front, through
+format-specific readers that stream the data into that on-disk layout and apply
+the cell/gene QC along the way.
+
+This vignette walks through every reader on a small synthetic data set, so it
+runs end-to-end without any downloads. It covers:
+
+- in-memory R objects (`load_r_data`)
+- 10x CellRanger MTX, single and multi-sample (`load_mtx`, `load_multi_mtx`)
+- AnnData `h5ad`, single and multi-sample (`load_h5ad`, `load_multi_h5ad`)
+- 10x CellRanger HDF5 (`load_tenx_h5`)
+- checkpointing to and from disk (`save_sc_exp_to_disk`, `load_existing`)
+
+If you have not seen the `SingleCells` class before, read the
+[design choices](https://gregorlueg.github.io/bixverse/articles/design_single_cell.html)
+vignette first.
+
+```{r}
+#| label: setup
+library(bixverse)
+library(data.table)
+library(Matrix)
+library(magrittr)
+```
+
+## A small synthetic data set
+
+We generate a synthetic data set and treat its two halves as two "samples", so
+that the multi-sample readers can be demonstrated too. The counts are a
+cell-by-gene `dgRMatrix`; `obs` and `var` are `data.table`s.
+
+```{r}
+#| label: synthetic data
+sim <- generate_single_cell_test_data()
+
+counts <- sim$counts # cells x genes (dgRMatrix)
+obs <- sim$obs
+var <- sim$var
+dim(counts)
+
+# two "samples" for the multi-sample examples
+idx_a <- 1:500
+idx_b <- 501:1000
+counts_a <- as(counts[idx_a, ], "RsparseMatrix")
+counts_b <- as(counts[idx_b, ], "RsparseMatrix")
+
+# scratch directories (one on-disk store per loaded object)
+base <- file.path(tempdir(), "bixverse_io")
+stores <- c(
+  "mtx_a", "mtx_b", "store_r", "store_mtx", "store_multi_mtx",
+  "store_h5", "store_multi_h5", "store_10x"
+)
+for (s in stores) dir.create(file.path(base, s), recursive = TRUE, showWarnings = FALSE)
+
+# light QC thresholds, suitable for this small toy data set
+qc <- params_sc_min_quality(
+  min_unique_genes = 5L,
+  min_lib_size = 10L,
+  min_cells = 3L
+)
+```
+
+## In-memory R objects
+
+The simplest entry point: hand the reader a cell-by-gene `dgRMatrix` plus the
+`obs` and `var` tables directly.
+
+```{r}
+#| label: load r data
+sc_r <- SingleCells(dir_data = file.path(base, "store_r"))
+sc_r <- load_r_data(
+  object = sc_r,
+  counts = counts,
+  obs = obs,
+  var = var,
+  sc_qc_param = qc,
+  .verbose = FALSE
+)
+sc_r
+```
+
+## 10x CellRanger MTX
+
+### Single sample
+
+We write one sample out in CellRanger flat-file form and point an explicit
+`params_sc_mtx_io()` at the trio (for real CellRanger output, the convenience
+helper `get_cell_ranger_params()` auto-locates `matrix.mtx` / `barcodes.tsv` /
+`genes.tsv`).
+
+```{r}
+#| label: write + load single mtx
+dir_a <- file.path(base, "mtx_a")
+# real CellRanger MTX is genes x cells, matching cells_as_rows = FALSE below
+write_cellranger_output(dir_a, counts_a, obs[idx_a], var, rows = "genes", .verbose = FALSE)
+
+mtx_params <- params_sc_mtx_io(
+  path_mtx = file.path(dir_a, "mat.mtx"),
+  path_obs = file.path(dir_a, "barcodes.csv"),
+  path_var = file.path(dir_a, "features.csv"),
+  cells_as_rows = FALSE,
+  has_hdr = TRUE
+)
+
+sc_mtx <- SingleCells(dir_data = file.path(base, "store_mtx"))
+sc_mtx <- load_mtx(
+  object = sc_mtx,
+  sc_mtx_io_param = mtx_params,
+  sc_qc_param = qc,
+  mtx_streaming = FALSE,
+  .verbose = FALSE
+)
+sc_mtx
+```
+
+### Multiple samples
+
+`prescan_mtx_dirs()` takes one directory per sample, builds the shared gene
+universe across them, and `load_multi_mtx()` then stacks all cells into a single
+object with a global gene QC. The originating sample is recorded in the `exp_id`
+`obs` column.
+
+```{r}
+#| label: write + load multi mtx
+dir_b <- file.path(base, "mtx_b")
+write_cellranger_output(dir_b, counts_b, obs[idx_b], var, rows = "genes", .verbose = FALSE)
+
+ps_mtx <- prescan_mtx_dirs(
+  dirs = c(dir_a, dir_b),
+  exp_ids = c("sample_a", "sample_b"),
+  has_hdr = TRUE
+)
+
+sc_multi_mtx <- SingleCells(dir_data = file.path(base, "store_multi_mtx"))
+sc_multi_mtx <- load_multi_mtx(
+  object = sc_multi_mtx,
+  prescan_result = ps_mtx,
+  sc_qc_param = qc,
+  .verbose = FALSE
+)
+sc_multi_mtx
+
+# cells per sample
+get_sc_obs(sc_multi_mtx)[, .N, by = exp_id]
+```
+
+## AnnData h5ad
+
+### Single
+
+`read_h5ad_metadata()` lets you inspect the `obs` / `var` and dimensions without
+loading the counts; `load_h5ad()` ingests the matrix.
+
+```{r}
+#| label: write + load single h5ad
+h5_a <- file.path(base, "sample_a.h5ad")
+write_h5ad_sc(h5_a, counts_a, obs[idx_a], var, .verbose = FALSE)
+
+meta <- read_h5ad_metadata(h5_a)
+meta$dims
+
+sc_h5 <- SingleCells(dir_data = file.path(base, "store_h5"))
+sc_h5 <- load_h5ad(
+  object = sc_h5,
+  h5_path = h5_a,
+  sc_qc_param = qc,
+  .verbose = FALSE
+)
+sc_h5
+```
+
+### Multiple
+
+`prescan_h5ad_files()` accepts a named vector of paths (the names become the
+sample identifiers); `load_multi_h5ad()` mirrors the multi-MTX workflow.
+
+```{r}
+#| label: write + load multi h5ad
+h5_b <- file.path(base, "sample_b.h5ad")
+write_h5ad_sc(h5_b, counts_b, obs[idx_b], var, .verbose = FALSE)
+
+ps_h5 <- prescan_h5ad_files(c(sample_a = h5_a, sample_b = h5_b))
+
+sc_multi_h5 <- SingleCells(dir_data = file.path(base, "store_multi_h5"))
+sc_multi_h5 <- load_multi_h5ad(
+  object = sc_multi_h5,
+  prescan_result = ps_h5,
+  sc_qc_param = qc,
+  .verbose = FALSE
+)
+sc_multi_h5
+```
+
+## 10x CellRanger HDF5
+
+`write_tenx_h5_sc()` expects the counts plus a barcode vector and a `features`
+table (with at least `id` and `name`). `load_tenx_h5()` reads the gene-expression
+modality (V3 files may also carry e.g. Antibody Capture, which is filtered out
+via `feature_type`).
+
+```{r}
+#| label: write + load 10x h5
+features <- data.table(id = var$gene_id, name = var$ensembl_id)
+h5_tenx <- file.path(base, "sample_a_10x.h5")
+write_tenx_h5_sc(
+  f_path = h5_tenx,
+  counts = counts_a,
+  barcodes = obs[idx_a]$cell_id,
+  features = features,
+  version = "v3"
+)
+
+sc_10x <- SingleCells(dir_data = file.path(base, "store_10x"))
+sc_10x <- load_tenx_h5(
+  object = sc_10x,
+  h5_path = h5_tenx,
+  sc_qc_param = qc,
+  feature_type = "Gene Expression",
+  .verbose = FALSE
+)
+sc_10x
+```
+
+::: {.callout-note}
+Multiple 10x `.h5` files: the streaming Rust combiner is implemented in
+`bixverse-rs` ([PR #27](https://github.com/GregorLueg/bixverse-rs/pull/27)) and
+will be exposed as `load_multi_10x()` once released; the workflow will mirror
+`prescan_h5ad_files()` / `load_multi_h5ad()`.
+:::
+
+## Checkpointing to disk
+
+Once an object is loaded, the in-memory mappings can be persisted so a fresh
+session can be restored without re-ingesting the counts. The on-disk binary and
+DuckDB already live in `dir_data`; `save_sc_exp_to_disk()` adds the lightweight
+mapping cache.
+
+```{r}
+#| label: save and restore
+save_sc_exp_to_disk(sc_h5, type = "rds")
+
+sc_restored <- SingleCells(dir_data = file.path(base, "store_h5"))
+sc_restored <- load_existing(sc_restored)
+sc_restored
+```
+
+## Summary
+
+| Format | Single sample | Multiple samples |
+| --- | --- | --- |
+| In-memory R | `load_r_data()` | -- |
+| 10x MTX | `load_mtx()` | `prescan_mtx_dirs()` + `load_multi_mtx()` |
+| AnnData h5ad | `load_h5ad()` | `prescan_h5ad_files()` + `load_multi_h5ad()` |
+| 10x HDF5 | `load_tenx_h5()` | *(`load_multi_10x()` -- forthcoming)* |
+| Seurat | `load_seurat()` | -- |
+
+All readers share the same `sc_qc_param` QC interface and write into the same
+on-disk `SingleCells` layout, so everything downstream (normalisation, HVGs,
+PCA, neighbours, clustering, ...) is identical regardless of how the data
+came in.
+```
+


### PR DESCRIPTION
Adds a self-contained **Single-cell data I/O** vignette (requested in #180) that walks through every ingestion reader on a small synthetic data set, so it runs end-to-end without any downloads:

- in-memory R (`load_r_data`)
- 10x MTX, single + multi-sample (`load_mtx`; `prescan_mtx_dirs` + `load_multi_mtx`)
- AnnData h5ad, single + multi-sample (`load_h5ad`; `prescan_h5ad_files` + `load_multi_h5ad`)
- 10x HDF5 (`load_tenx_h5`)
- checkpointing (`save_sc_exp_to_disk` + `load_existing`)

Verified with `quarto render` — all chunks execute. Indexed in `_pkgdown.yml` (Single Cells articles + navbar). A forthcoming `load_multi_10x()` (GregorLueg/bixverse-rs#27) is noted and will slot into the same `prescan_* + load_multi_*` pattern.

> Heads-up — unrelated to this PR: pkgdown CI on `feat-citeseq` currently fails at `build_reference_index()` because `_pkgdown.yml`'s reference index is out of sync with the branch's exports — 44 documented functions (ADT/CITE-seq, multi-modal, 10x; incl. `load_multi_mtx` and `write_tenx_h5_sc`) and 2 vignettes (`multi_modal_single_cells`, `single-cell-visualisation`) are missing from the index. That needs a reference-index sync (or `@keywords internal` for the helpers). Happy to take a pass at it if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
