### PR TITLE
fix: NA gene ids in multi-file var table under gene_universe = "union"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,15 @@ Following things were added:
 * NMF for bulk and single cell.
    
 
+## Bug fixes
+
+* Multi-file loaders (`load_multi_tenx_h5()`, `load_multi_h5ad()`) no longer
+  write `NA` gene ids into the `var` table under `gene_universe = "union"` when
+  the var reference file does not contain every gene in the universe. The
+  `gene_id` is now pinned to the canonical universe id (counts were already
+  ingested correctly); a warning reports genes whose `gene_name`/`feature_type`
+  metadata is unavailable from the reference file.
+
 ## Breaking changes
 
 The interface to the i/o functions for the single cell was changed. The 

--- a/R/classes_single_cell_db.R
+++ b/R/classes_single_cell_db.R
@@ -1239,6 +1239,20 @@ SingleCellDuckDB <- R6::R6Class(
 
       var_dt <- self$get_vars_table()
       var_dt <- var_dt[match(final_gene_names, gene_id)]
+      # gene_universe = "union" can include genes absent from the var reference
+      # file; pin gene_id to the canonical universe id so the var <-> counts
+      # mapping is never NA-keyed (counts for those genes are ingested correctly)
+      n_missing_meta <- sum(is.na(var_dt$gene_id))
+      if (n_missing_meta > 0L) {
+        warning(sprintf(
+          paste(
+            "%d gene(s) absent from the var reference file; metadata limited",
+            "to gene_id (gene_universe = 'union')."
+          ),
+          n_missing_meta
+        ))
+      }
+      var_dt[, gene_id := final_gene_names]
       var_dt[, gene_idx := .I]
 
       con <- private$connect_db()
@@ -1825,6 +1839,20 @@ SingleCellDuckDB <- R6::R6Class(
 
       var_dt <- self$get_vars_table()
       var_dt <- var_dt[match(final_gene_names, gene_id)]
+      # gene_universe = "union" can include genes absent from the var reference
+      # file; pin gene_id to the canonical universe id so the var <-> counts
+      # mapping is never NA-keyed (counts for those genes are ingested correctly)
+      n_missing_meta <- sum(is.na(var_dt$gene_id))
+      if (n_missing_meta > 0L) {
+        warning(sprintf(
+          paste(
+            "%d gene(s) absent from the var reference file; metadata limited",
+            "to gene_id (gene_universe = 'union')."
+          ),
+          n_missing_meta
+        ))
+      }
+      var_dt[, gene_id := final_gene_names]
 
       if ("gene_idx" %in% names(var_dt)) {
         var_dt[, gene_idx := NULL]
@@ -1976,6 +2004,20 @@ SingleCellDuckDB <- R6::R6Class(
       )
 
       var_dt <- var_dt[match(final_gene_names, gene_id)]
+      # gene_universe = "union" can include genes absent from the var reference
+      # source; pin gene_id to the canonical universe id so the var <-> counts
+      # mapping is never NA-keyed (counts for those genes are ingested correctly)
+      n_missing_meta <- sum(is.na(var_dt$gene_id))
+      if (n_missing_meta > 0L) {
+        warning(sprintf(
+          paste(
+            "%d gene(s) absent from the var reference source; metadata limited",
+            "to gene_id (gene_universe = 'union')."
+          ),
+          n_missing_meta
+        ))
+      }
+      var_dt[, gene_id := final_gene_names]
 
       if ("gene_idx" %in% names(var_dt)) {
         var_dt[, gene_idx := NULL]
@@ -2138,6 +2180,20 @@ SingleCellDuckDB <- R6::R6Class(
       }
 
       dt <- dt[match(final_gene_names, gene_id)]
+      # gene_universe = "union" can include genes absent from the var reference
+      # file; pin gene_id to the canonical universe id so the var <-> counts
+      # mapping is never NA-keyed (counts for those genes are ingested correctly)
+      n_missing_meta <- sum(is.na(dt$gene_id))
+      if (n_missing_meta > 0L) {
+        warning(sprintf(
+          paste(
+            "%d gene(s) absent from the var reference file; metadata limited",
+            "to gene_id (gene_universe = 'union')."
+          ),
+          n_missing_meta
+        ))
+      }
+      dt[, gene_id := final_gene_names]
 
       if ("gene_idx" %in% names(dt)) {
         dt[, gene_idx := NULL]

--- a/inst/tinytest/test_sc_io_10x.R
+++ b/inst/tinytest/test_sc_io_10x.R
@@ -728,6 +728,40 @@ expect_equal(
   info = "multi tenx prescan - union universe size"
 )
 
+### full multi load: union (regression - gene metadata never NA) -------------
+
+# file A is the var reference (first file) and lacks the genes only present in
+# file B; under gene_universe = "union" the var table must not be NA-keyed
+dir_multi_union <- file.path(test_temp_dir, "sc_multi_tenx_union")
+dir.create(dir_multi_union, recursive = TRUE, showWarnings = FALSE)
+
+sc_union <- SingleCells(dir_data = dir_multi_union)
+sc_union <- suppressWarnings(load_multi_tenx_h5(
+  object = sc_union,
+  prescan_result = prescan_union,
+  sc_qc_param = sc_qc_param,
+  streaming = 0L,
+  .verbose = FALSE
+))
+
+var_union <- get_sc_var(sc_union)
+
+expect_false(
+  current = anyNA(var_union$gene_id),
+  info = "multi tenx (union) - no NA gene_id in var table"
+)
+
+expect_true(
+  current = all(var_union$gene_id %in% rna$var$gene_id[genes_union_idx]),
+  info = "multi tenx (union) - var gene ids are canonical universe ids"
+)
+
+expect_equal(
+  current = nrow(var_union),
+  target = dim(sc_union)[2],
+  info = "multi tenx (union) - var rows match gene matrix dimension"
+)
+
 ### prescan: ADT filtered out from multi modal file --------------------------
 
 prescan_mm <- prescan_tenx_h5_files(


### PR DESCRIPTION
## Problem
The reordered var-table population (`populate_vars_from_tenx_h5_reordered`, `populate_vars_from_h5ad_reordered`, `populate_vars_from_duckdb_reordered`, `populate_vars_from_plain_text_reordered`) reads gene metadata from a single reference file (`file_tasks[[1]]`) and reorders with `var_dt[match(final_gene_names, gene_id)]`.

Under `gene_universe = "union"` the universe can contain genes present only in non-reference files. `match()` returns `NA` for those, producing var rows with `NA` `gene_id`/`gene_name`/`feature_type` while their counts are ingested correctly. `get_var_index_map()` then builds `setNames(index, gene_id)`, so the gene -> index map gains `NA`-keyed entries and the var table desyncs from the count matrix. `gene_universe = "intersection"` (default) is unaffected: the universe is a subset of every file, so the reference file always contains every gene.

## Reproduction
On the existing multi-file fixtures (file A = genes 1:80 as reference, file B = genes 21:100, union = 1:100): the 20 union genes present only in B become `NA`-keyed rows.

## Fix
After the `match()`, pin `gene_id` to the canonical universe id (`var_dt[, gene_id := final_gene_names]`) so the var <-> counts mapping is never `NA`-keyed, and warn when reference-file metadata (`gene_name`/`feature_type`) is unavailable for some genes. Applied to all four reorder methods: `tenx`/`h5ad` are reachable today (`prescan_tenx_h5_files()` / `prescan_h5ad_files()` both expose `"union"`); `duckdb`/`plain_text` share the identical pattern and get the same guard.

## Test
Adds a union-mode load regression to `test_sc_io_10x.R` (reuses the existing multi-file fixtures): asserts the loaded `var` table has no `NA` `gene_id`, gene ids are canonical universe ids, and var rows match the gene-matrix dimension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
