### PR TITLE
fix: build the document bin in release

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -40,7 +40,7 @@ $(STATLIB):
 
 	export CARGO_HOME=$(CARGOTMP) && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-	cargo run @CRAN_FLAGS@ --bin document --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
+	cargo run @CRAN_FLAGS@ @PROFILE@ --bin document --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
 
 	# Always clean up CARGOTMP
 	rm -Rf $(CARGOTMP);

--- a/src/Makevars.win.in
+++ b/src/Makevars.win.in
@@ -39,7 +39,7 @@ $(STATLIB):
 	# Generate wrappers
 	export CARGO_HOME=$(CARGOTMP) && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-	cargo run @CRAN_FLAGS@ --bin document --target $(TARGET) --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+	cargo run @CRAN_FLAGS@ @PROFILE@ --bin document --target $(TARGET) --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 	# Always clean up CARGOTMP
 	rm -Rf $(CARGOTMP);


### PR DESCRIPTION
config.R pins .profile to --release, but neither Makevars passed @PROFILE@ to the document bin, so every build compiled the lib and its whole dependency tree a second time under the dev profile just to generate the wrappers.