### PR TITLE
chore: adopt the copier template

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,0 +1,15 @@
+# Managed by copier. Edits here are overwritten on the next update.
+# Change an answer with: copier update --data key=value
+_commit: v1.0.0
+_src_path: gh:GregorLueg/personal-templates
+ci_rust: true
+extra_sysdeps: ''
+has_gpu: false
+has_rust: true
+linux_runner: ubuntu-22.04
+pkg_name: bixverse
+quarto: true
+rebuild_from_source: stringfish qs2
+rust_toolchain: stable
+windows: false
+

--- a/.github/workflows/R-cmd-check.yml
+++ b/.github/workflows/R-cmd-check.yml
@@ -16,7 +16,6 @@ jobs:
     with:
       rust: true
       gpu: false
-      # No Windows: the HDF5 toolchain is the blocker.
       windows: false
       linux-runner: ubuntu-22.04
       rebuild-from-source: 'stringfish qs2'

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>GregorLueg/personal-actions"]
+}

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -13,8 +13,8 @@ CARGOTMP = $(CURDIR)/.cargo
 VENDOR_DIR = $(CURDIR)/vendor
 
 
-# RUSTFLAGS appends --print=native-static-libs to ensure that 
-# the correct linkers are used. Use this for debugging if need. 
+# RUSTFLAGS appends --print=native-static-libs to ensure that
+# the correct linkers are used. Use this for debugging if need.
 #
 # CRAN note: Cargo and Rustc versions are reported during
 # configure via tools/msrv.R.
@@ -38,6 +38,9 @@ $(STATLIB):
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
 	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
 
+	# @PROFILE@ matters here. config.R pins it to --release, and without it
+	# cargo builds the document bin into target/debug, recompiling the lib and
+	# every transitive dependency a second time just to emit the wrappers.
 	export CARGO_HOME=$(CARGOTMP) && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
 	cargo run @CRAN_FLAGS@ @PROFILE@ --bin document --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@

--- a/src/Makevars.win.in
+++ b/src/Makevars.win.in
@@ -36,7 +36,7 @@ $(STATLIB):
 	export LIBRARY_PATH="$(LIBRARY_PATH);$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
 	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --target=$(TARGET) --lib @PROFILE@ --manifest-path=rust/Cargo.toml --target-dir=$(TARGET_DIR)
 
-	# Generate wrappers
+	# Generate wrappers. @PROFILE@ matters here, see Makevars.in.
 	export CARGO_HOME=$(CARGOTMP) && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
 	cargo run @CRAN_FLAGS@ @PROFILE@ --bin document --target $(TARGET) --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)

--- a/src/rust/vendor-config.toml
+++ b/src/rust/vendor-config.toml
@@ -1,10 +1,5 @@
 [source.crates-io]
 replace-with = "vendored-sources"
 
-[source."git+https://github.com/GregorLueg/bixverse-rs.git?branch=release-0.1.8"]
-git = "https://github.com/GregorLueg/bixverse-rs.git"
-branch = "release-0.1.8"
-replace-with = "vendored-sources"
-
 [source.vendored-sources]
-directory = "vendor"
+directory = "../vendor"


### PR DESCRIPTION
Scaffolding only, no behaviour change: this package already registers the panic hook.

Fixes vendor-config.toml, which pointed at directory = "vendor" when the config lands in src/.cargo/ and the vendor dir sits at src/vendor, so the relative path was wrong. Also drops a stale git source override pinning bixverse-rs to a release-0.1.8 branch, dead since the move to crates.io versions. Both only bite on offline vendored builds.